### PR TITLE
Update Pages workflow to build site

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -33,11 +33,13 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+      - name: Build site
+        run: bundle exec jekyll build -d _site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
-          path: '.'
+          path: '_site'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- build the Jekyll site before uploading
- upload `_site` directory to GitHub Pages

## Testing
- `bundle exec jekyll build -d _site` *(fails: bundler not installed)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d472b2d90832bba154173f5776ea1